### PR TITLE
Add library.properties metadata file

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,0 +1,10 @@
+name=PWFusion_AS3935_I2C
+version=0.0.0
+author=Playing With Fusion, Inc.
+maintainer=Playing With Fusion, Inc.
+sentence=I2C Library for AS3935 Lightning Sensor.
+paragraph=Designed to use antenna calibration (capacitance) value provided with the board. Example file hardware descripion is designed to work with Playing With Fusion breakout board SEN-39001, currently R01.
+category=Sensors
+url=https://github.com/signorettae/AS3935_arduino_wire_library
+architectures=avr
+includes=PWFusion_AS3935_I2C.h


### PR DESCRIPTION
Libraries in the Arduino Library 1.5 format (source files under the src subfolder) are required to have a library.properties file in the root folder. If this file is not present the library is not recognized by the Arduino IDE.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#library-metadata